### PR TITLE
update pyenv to use pyenv installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,14 @@ RUN apt-get update && \
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.UTF-8
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git ca-certificates && \
-        git clone https://github.com/pyenv/pyenv.git .pyenv && \
-        (cd .pyenv && git checkout v1.2.2) && \
-    apt-get purge -y --auto-remove git ca-certificates && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
 ENV PYENV_ROOT="/.pyenv" \
     PATH="/.pyenv/bin:/.pyenv/shims:$PATH"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git ca-certificates curl && \
+    curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash && \
+    apt-get purge -y --auto-remove ca-certificates curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ ENV LANG en_US.UTF-8
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git ca-certificates && \
-        git clone https://github.com/yyuu/pyenv.git .pyenv && \
-        (cd .pyenv && git checkout v1.0.6) && \
+        git clone https://github.com/pyenv/pyenv.git .pyenv && \
+        (cd .pyenv && git checkout v1.2.2) && \
     apt-get purge -y --auto-remove git ca-certificates && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -27,7 +27,8 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ONBUILD COPY python-versions.txt ./
-ONBUILD RUN xargs -P 4 -n 1 pyenv install < python-versions.txt && \
+ONBUILD RUN pyenv update && \
+            xargs -P 4 -n 1 pyenv install < python-versions.txt && \
             pyenv global $(pyenv versions --bare) && \
             find $PYENV_ROOT/versions -type d '(' -name '__pycache__' -o -name 'test' -o -name 'tests' ')' -exec rm -rfv '{}' + && \
             find $PYENV_ROOT/versions -type f '(' -name '*.py[co]' -o -name '*.exe' ')' -exec rm -fv '{}' +


### PR DESCRIPTION
Switch pyenv to pyenv installer, added `pyenv update` command to the onbuild so we won't need to change this image every time new version of python is released